### PR TITLE
Use proper error logging

### DIFF
--- a/src/ghe.coffee
+++ b/src/ghe.coffee
@@ -30,7 +30,7 @@ module.exports = (robot) ->
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"
 
   unless token
-    msg.send "token isn't set."
+    robot.logger.error "GitHub Enterprise token isn't set."
 
   robot.respond /ghe license$/i, (msg) ->
     ghe_license msg,token,url


### PR DESCRIPTION
As reported in #2 `msg` was not defined which meant a cryptic error was thrown when `HUBOT_GHE_TOKEN` was not set up.

This PR changes this section to use proper error logging instead.
